### PR TITLE
Add citation and license files

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,8 +17,9 @@ authors:
     orcid: 'https://orcid.org/0000-0002-7430-7879'
   - given-names: Jeremy
     family-names: Weiss
-    email: azmet@arizona.edu
+    email: jlweiss@arizona.edu
     affiliation: University of Arizona Cooperative Extension
+    orcid: https://orcid.org/0000-0003-3597-0712
 repository-code: 'https://github.com/uace-azmet/azmet-qa-dashboard'
 license: MIT
 version: v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: AZMet QA Dashboard
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Eric R
+    family-names: Scott
+    email: ericrscott@arizona.edu
+    affiliation: >-
+      University of Arizona, Communications & Cyber
+      Technologies Data Science team
+    orcid: 'https://orcid.org/0000-0002-7430-7879'
+  - given-names: Jeremy
+    family-names: Weiss
+    email: azmet@arizona.edu
+    affiliation: University of Arizona Cooperative Extension
+repository-code: 'https://github.com/uace-azmet/azmet-qa-dashboard'
+license: MIT
+version: v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
     family-names: Scott
     email: ericrscott@arizona.edu
     affiliation: >-
-      University of Arizona, Communications & Cyber
+      University of Arizona Experiment Station, Communications & Cyber
       Technologies Data Science team
     orcid: 'https://orcid.org/0000-0002-7430-7879'
   - given-names: Jeremy

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2024 azmet-qa-dashboard authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ This project uses [`renv`](https://rstudio.github.io/renv/articles/renv.html) fo
 ## Collaboration guidelines
 
 To contribute to this project, please create a new branch for your changes and make a pull request. One easy way to do this from within R is with the `usethis` package and the `pr_*` functions. `pr_init("branch-name")` begins a new branch locally, `pr_push()` helps you create a new pull request, and after it is merged you can use `pr_finish()` to clean things up. More about this workflow [here](https://usethis.r-lib.org/articles/pr-functions.html).
+
+------------------------------------------------------------------------
+Developed in collaboration with the University of Arizona [CCT Data Science](https://datascience.cct.arizona.edu/) team


### PR DESCRIPTION
Adds an MIT license (CCTs standard license for code) and a CITATION.cff file to make this repo easier to cite.  In prep for archiving with Zenodo (#50).