### PR TITLE
use `pak` for package isntallation on github actions

### DIFF
--- a/.github/workflows/deploy-to-connect.yaml
+++ b/.github/workflows/deploy-to-connect.yaml
@@ -28,20 +28,24 @@ jobs:
           use-public-rspm: true
           extra-repositories: 'https://cct-datascience.r-universe.dev'
       
-      - name: Install System Dependencies
-        run: |
-          sudo apt-get install libudunits2-dev
+      # System dependencies handled by `renv` + `pak`
+      # - name: Install System Dependencies
+      #   run: |
+      #     sudo apt-get install libudunits2-dev
 
       - uses: r-lib/actions/setup-renv@v2
+        env:
+          RENV_CONFIG_PAK_ENABLED: true
         with:
           cache-version: 3
       
+      #this might not be necessary?
       - name: Install packages required for Posit Connect
         shell: Rscript {0}
         run: |
-          if (!requireNamespace("packrat", quietly = TRUE)) install.packages("packrat")
-          if (!requireNamespace("rsconnect", quietly = TRUE)) install.packages("rsconnect")
-          if (!requireNamespace("Cairo", quietly = TRUE)) install.packages("Cairo")
+          if (!requireNamespace("packrat", quietly = TRUE)) pak::pak("packrat")
+          if (!requireNamespace("rsconnect", quietly = TRUE)) pak::pak("rsconnect")
+          if (!requireNamespace("Cairo", quietly = TRUE)) pak::pak("Cairo")
           
       - name: Generate manifest.json
         run: |


### PR DESCRIPTION
Deploy action is failing (#53) due to missing system dependency for `systemfonts`.  A future-proof fix is to use `pak` as the "engine" for installing packages rather than base R `install.packages()`.  `pak` is aware of package system dependencies and installs them automatically on linux runners.  We won't know if this works until I merge it, but it shouldn't break things any more!